### PR TITLE
Improve detection of timezone name

### DIFF
--- a/strftime.js
+++ b/strftime.js
@@ -260,7 +260,7 @@
             return "GMT";
           }
           else {
-            var tzString = d.toString().match(/\((\w+)\)/);
+            var tzString = d.toString().match(/\(([\w\s]+)\)/);
             return tzString && tzString[1] || '';
           }
 


### PR DESCRIPTION
Timezone name can contain contain spaces (ex. "GTB Daylight Time" or "Pacific Daylight Time") this is why we should use [\w\s+] instead of \w.
