### PR TITLE
added support for extended offset format

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -111,11 +111,12 @@ e.g. `%q` becomes `q`. Use `%%` to get a literal `%` sign.
 For more detail see `man 3 strftime` as the format specifiers should behave
 identically. If behaviour differs please [file a bug](https://github.com/samsonjs/strftime/issues/new).
 
-Any specifier can be modified with `-`, `_`, or `0` as well, as in Ruby.
+Any specifier can be modified with `-`, `_`, `0`, or `:` as well, as in Ruby.
 Using `%-` will omit any leading zeroes or spaces, `%_` will force spaces
 for padding instead of the default, and `%0` will force zeroes for padding.
 There's some redundancy here as `%-d` and `%e` have the same result, but it
-solves some awkwardness with formats like `%l`.
+solves some awkwardness with formats like `%l`. Using `%:` for time zone offset,
+as in `%:z` will insert a colon as a delimiter.
 
 Contributors
 ============

--- a/strftime.js
+++ b/strftime.js
@@ -114,8 +114,8 @@
     // Most of the specifiers supported by C's strftime, and some from Ruby.
     // Some other syntax extensions from Ruby are supported: %-, %_, and %0
     // to pad with nothing, space, or zero (respectively).
-    return fmt.replace(/%([-_0]?.)/g, function(_, c) {
-      var mod, padding;
+    return fmt.replace(/%([-_0:]?.)/g, function(_, c) {
+      var mod, padding, ext;
 
       if (c.length == 2) {
         mod = c[0];
@@ -130,6 +130,9 @@
         // pad with zero
         else if (mod == '0') {
           padding = '0';
+        }
+        else if (mod == ":") {
+          ext = true;
         }
         else {
           // unrecognized, return the format
@@ -267,11 +270,12 @@
         // '+0000'
         case 'z':
           if (options.utc) {
-            return "+0000";
+            return ext ? "+00:00" : "+0000";
           }
           else {
             var off = typeof tz == 'number' ? tz : -d.getTimezoneOffset();
-            return (off < 0 ? '-' : '+') + pad(Math.floor(Math.abs(off) / 60)) + pad(Math.abs(off) % 60);
+            var sep = ext ? ":" : ""; // separator for extended offset
+            return (off < 0 ? '-' : '+') + pad(Math.floor(Math.abs(off) / 60)) + sep + pad(Math.abs(off) % 60);
           }
 
         default: return c;

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,7 @@ assert.format('%Y', '2011')
 assert.format('%y', '11')
 assert.format('%Z', null, 'GMT')
 assert.format('%z', null, '+0000')
+assert.format('%:z', null, '+00:00')
 assert.format('%%', '%') // any other char
 assert.format('%F %T', null, '1970-01-01 00:00:00', new Date(0))
 ok('GMT')
@@ -175,6 +176,7 @@ assert.formatTZ('%F %r %z', '2011-06-07 08:51:45 PM +0200', '+0200')
 assert.formatTZ('%F %r %z', '2011-06-07 11:51:45 AM -0700', -420)
 assert.formatTZ('%F %r %z', '2011-06-07 11:51:45 AM -0700', '-0700')
 assert.formatTZ('%F %r %z', '2011-06-07 11:21:45 AM -0730', '-0730')
+assert.formatTZ('%F %r %:z', '2011-06-07 11:21:45 AM -07:30', '-0730')
 ok('Time zone offset')
 
 
@@ -221,5 +223,6 @@ function testTimezone(regex) {
     assert.format('%T', T, '18:51:45')
     assert.format('%Z', tz, 'GMT')
     assert.format('%z', sign + '0' + Math.abs(hourDiff) + '00', '+0000')
+    assert.format('%:z', sign + '0' + Math.abs(hourDiff) + ':00', '+00:00')
   }
 }


### PR DESCRIPTION
This adds support for formatting the UTC offset with a colon (+/-HH:MM). This is done by adding a colon as a modifier: `%:z`.