### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
   "engines": {
     "node": ">=0.2.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://sjs.mit-license.org"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/