### PR TITLE
Pass through unrecognized directives

### DIFF
--- a/strftime.js
+++ b/strftime.js
@@ -494,6 +494,8 @@
                             break;
 
                         default:
+                            if (isInScope)
+                                resultString += '%';
                             resultString += format[i];
                             break;
                     }


### PR DESCRIPTION
For compatibility with strftime() on Unix, preserve the percent sign for unrecognized directives when appending to resultString.