### PR TITLE
Make strftime play nice with dates that have been extended by DateJS

### DIFF
--- a/strftime.js
+++ b/strftime.js
@@ -74,7 +74,7 @@
     adaptForwards(adaptedStrftime);
     function adaptedStrftime(fmt, d, locale) {
         // d and locale are optional, check if this is (format, locale)
-        if (d && d.days) {
+        if (d && d.days && !d.getTime) {
             locale = d;
             d = undefined;
         }


### PR DESCRIPTION
A project of mine uses [DateJS](https://github.com/abritinthebay/datejs) (which may or may not be a good idea), and it causes strftime to not use the default locale (and thereby throw an error unless you have supplied a locale yourself) because the date argument will have a `days` key, making strftime believe that it is in fact a locale argument.

I added a simple check to make sure the argument does not have a typical date key (`getTime`), which should never be present in a locale (AFAICT). All tests pass.
