### PR TITLE
fix it_IT shortMonths locale

### DIFF
--- a/strftime.js
+++ b/strftime.js
@@ -138,7 +138,7 @@
             days: ['domenica', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato'],
             shortDays: ['dom', 'lun', 'mar', 'mer', 'gio', 'ven', 'sab'],
             months: ['gennaio', 'febbraio', 'marzo', 'aprile', 'maggio', 'giugno', 'luglio', 'agosto', 'settembre', 'ottobre', 'novembre', 'dicembre'],
-            shortMonths: ['pr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic'],
+            shortMonths: ['gen', 'feb', 'mar', 'apr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic'],
             AM: 'AM',
             PM: 'PM',
             am: 'am',


### PR DESCRIPTION
There is a small problem in location `it_IT` `shortMonths` array. It is returning different dates and undefined when using italian locale